### PR TITLE
Add Gamma ramp; properly cumulate temp, brightness, gamma, inversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,12 @@ $ busctl --user introspect rs.wl-gammarelay / rs.wl.gammarelay
 NAME               TYPE      SIGNATURE RESULT/VALUE FLAGS
 .ToggleInverted    method    -         -            -
 .UpdateBrightness  method    d         -            -
+.UpdateGamma       method    d         -            -
 .UpdateTemperature method    n         -            -
 .Brightness        property  d         1            emits-change writable
+.Gamma             property  d         1            emits-change writable
 .Inverted          property  b         false        emits-change writable
-.Temperature       property  q         4500         emits-change writable
+.Temperature       property  q         6500         emits-change writable
 ```
 
 ## Installation
@@ -41,6 +43,12 @@ i3status-rust hueshift block has the builtin support for this backend since 0.21
         "exec": "wl-gammarelay-rs watch {bp}",
         "on-scroll-up": "busctl --user -- call rs.wl-gammarelay / rs.wl.gammarelay UpdateBrightness d +0.02",
         "on-scroll-down": "busctl --user -- call rs.wl-gammarelay / rs.wl.gammarelay UpdateBrightness d -0.02"
+    }
+    "custom/wl-gammarelay-gamma": {
+        "format": "{}% γ",
+        "exec": "wl-gammarelay-rs watch {g}",
+        "on-scroll-up": "busctl --user -- call rs.wl-gammarelay / rs.wl.gammarelay UpdateGamma d +0.02",
+        "on-scroll-down": "busctl --user -- call rs.wl-gammarelay / rs.wl.gammarelay UpdateGamma d -0.02"
     }
 ```
 
@@ -86,4 +94,13 @@ busctl --user call rs.wl-gammarelay / rs.wl.gammarelay UpdateBrightness d 0.1
 
 # Decrease the brightness by `10%`:
 busctl --user -- call rs.wl-gammarelay / rs.wl.gammarelay UpdateBrightness d -0.1
+
+# Set display gamma to `1.0`:
+busctl --user set-property rs.wl-gammarelay / rs.wl.gammarelay Gamma d 1
+
+# Increase gamma by `0.1`:
+busctl --user call rs.wl-gammarelay / rs.wl.gammarelay UpdateGamma d 0.1
+
+# Decrease gamma by `0.1`:
+busctl --user -- call rs.wl-gammarelay / rs.wl.gammarelay UpdateGamma d -0.1
 ```

--- a/src/dbus_client.rs
+++ b/src/dbus_client.rs
@@ -6,14 +6,19 @@ pub async fn watch_dbus(format: &str) -> Result<()> {
     let conn = zbus::ConnectionBuilder::session()?.build().await?;
     let proxy = BusInterfaceProxy::new(&conn).await?;
     let mut temperature = proxy.temperature().await?;
+    let mut gamma = proxy.gamma().await?;
     let mut brightness = proxy.brightness().await?;
     let mut t_stream = proxy.receive_temperature_changed().await;
+    let mut g_stream = proxy.receive_gamma_changed().await;
     let mut b_stream = proxy.receive_brightness_changed().await;
     loop {
-        print_formatted(format, temperature, brightness);
+        print_formatted(format, temperature, gamma, brightness);
         tokio::select! {
             Some(t) = t_stream.next() => {
                 temperature = t.get().await?;
+            }
+            Some(g) = g_stream.next() => {
+                gamma = g.get().await?;
             }
             Some(b) = b_stream.next() => {
                 brightness = b.get().await?;
@@ -22,11 +27,12 @@ pub async fn watch_dbus(format: &str) -> Result<()> {
     }
 }
 
-fn print_formatted(format: &str, temperature: u16, brightness: f64) {
+fn print_formatted(format: &str, temperature: u16, gamma: f64, brightness: f64) {
     println!(
         "{}",
         format
             .replace("{t}", &temperature.to_string())
+            .replace("{g}", &format!("{:.2}", gamma))
             .replace("{b}", &format!("{:.2}", brightness))
             .replace("{bp}", &format!("{:.0}", brightness * 100.))
     );
@@ -41,6 +47,9 @@ trait BusInterface {
     /// UpdateBrightness method
     fn update_brightness(&self, delta_brightness: f64) -> zbus::Result<()>;
 
+    /// UpdateGamma method
+    fn update_gamma(&self, delta_gamma: f64) -> zbus::Result<()>;
+
     /// UpdateTemperature method
     fn update_temperature(&self, delta_temp: i16) -> zbus::Result<()>;
 
@@ -49,6 +58,12 @@ trait BusInterface {
     fn brightness(&self) -> zbus::Result<f64>;
     #[dbus_proxy(property)]
     fn set_brightness(&self, value: f64) -> zbus::Result<()>;
+
+    /// Gamma property
+    #[dbus_proxy(property)]
+    fn gamma(&self) -> zbus::Result<f64>;
+    #[dbus_proxy(property)]
+    fn set_gamma(&self, value: f64) -> zbus::Result<()>;
 
     /// Temperature property
     #[dbus_proxy(property)]

--- a/toggle-invert-display.sh
+++ b/toggle-invert-display.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# The human eye is more sensitive to contrast at high than at low
+# levels of intensity. Thus, contast at high levels of intensity is
+# lost if the display is inverted. This script compensates for this by
+# gamma correction. The value of γ=0.6 is not based on any theory;
+# adjust it to your liking.
+
+dbus="rs.wl-gammarelay / rs.wl.gammarelay"
+
+if [ "$(busctl --user get-property $dbus Inverted)" = "b false" ]; then
+    busctl --user set-property $dbus Inverted b true
+    busctl --user set-property $dbus Gamma d 0.6
+else
+    busctl --user set-property $dbus Inverted b false
+    busctl --user set-property $dbus Gamma d 1.0
+fi


### PR DESCRIPTION
This works flawlessly for me, but check carefully - this is my first hackery in Rust, and I don't know Rust.

You probably want to squash the commits (sorry) on merging.

As an aside, I noticed that the symbols in the Waybar example (where Gamma uses γ) use Unicode code points from a private use area and are thus unlikely to be displayed properly for many users (including me). 