### PR TITLE
fix and improve `auto-temperature.py` script

### DIFF
--- a/scripts/auto-temperature.py
+++ b/scripts/auto-temperature.py
@@ -1,33 +1,49 @@
-import datetime as dt
-import time
+#!/usr/bin/python
+"""Change screen temperature depending on dawn/dusk time."""
+
 import subprocess
+from datetime import datetime
+from time import sleep
 
-## Tested parameter space:
-# dusk_time < 3600 + dawn_time
-# 3600 < dusk_time
 
-temp_day = 6500
-temp_night = 3800
-dawn_time = 9 * 3600  # 9am
-dusk_time = 19 * 3600  # 19pm
+TEMP_DAY = 6500.0
+TEMP_NIGHT = 3800.0
+
+DAWN_TIME = 9 * 3600.0  # 9am (Should be > WINDOW)
+DUSK_TIME = 19 * 3600.0  # 19pm (Shoulbe be > WINDOW + DAWN_TIME)
+
+WINDOW = 900  # 15m (The time during which the temperature changes gradually until it reaches the desired value)
+
+
+temp = None
 
 while True:
-    temp = temp_day
-    now = dt.datetime.now()
-    curr_time = int(
-        (now - now.replace(hour=0, minute=0, second=0, microsecond=0)).total_seconds()
-    )
-    if dawn_time - 3600 < curr_time < dawn_time:
-        temp = (dawn_time - curr_time) * (temp_night - temp_day) / 3600 + temp_day
-    if dusk_time - 3600 < curr_time < dusk_time:
-        temp = (dusk_time - curr_time) * (temp_day - temp_night) / 3600 + temp_night
-        print("check")
-    if dusk_time < curr_time or curr_time < dawn_time:
-        temp = temp_night
-    temp = int(temp)
-    subprocess.run(
-        f"busctl --user set-property rs.wl-gammarelay / rs.wl.gammarelay Temperature q {temp}",
-        shell=True,
-    )
-    time.sleep(1)
+    now = datetime.now().astimezone()
+    # Seconds since the beginning of day
+    current_time = now.hour * 3600 + now.minute * 60 + now.second
 
+    if DAWN_TIME - WINDOW < current_time < DAWN_TIME:
+        temp = (DAWN_TIME - current_time) * (TEMP_NIGHT - TEMP_DAY) / WINDOW + TEMP_DAY
+    elif DUSK_TIME - WINDOW < current_time < DUSK_TIME:
+        temp = (DUSK_TIME - current_time) * (TEMP_DAY - TEMP_NIGHT) / WINDOW + TEMP_NIGHT
+    elif current_time > DUSK_TIME or current_time < DAWN_TIME:
+        temp = TEMP_NIGHT
+    elif current_time > DAWN_TIME or current_time < DUSK_TIME:
+        temp = TEMP_DAY
+
+    if temp:
+        subprocess.run(
+            [
+                "busctl",
+                "--user",
+                "set-property",
+                "rs.wl-gammarelay",
+                "/",
+                "rs.wl.gammarelay",
+                "Temperature",
+                "q",
+                str(int(temp)),
+            ]
+        )
+
+    sleep(1)


### PR DESCRIPTION
Now it should not suddenly jump to `TEMP_DAY` when current_time == DUSK_TIME.

Also, I made some performance and portability improvments. Other performance improvments can be made, but it might reduce accuracy and  lead to unexpected results.

Also, the WINDOW is now 15m rather than 30m, since 15m are enough for the eyes to not notice.

---

The bug was here:
https://github.com/MaxVerevkin/wl-gammarelay-rs/blob/cf7906769a6260d5a97ead60b40fa0c07c50a12f/scripts/auto-temperature.py#L25
It should be:
```python
 if dusk_time <= curr_time or curr_time < dawn_time: 
```